### PR TITLE
feat(pdf-download): enable CORS with credentials

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8943,7 +8943,7 @@ var pdfjsWebLibs = {
       }
 
       if (file) {
-        PDFViewerApplication.open(file);
+        PDFViewerApplication.open(file, {"withCredentials": true});
       }
     }
 


### PR DESCRIPTION
This PR allows our PDFViewer to download PDF files with CORS and credentials (e.g. cookies). To anyone reviewing this:

* There might be a better implementation, maybe by externalizing the parameter
* Dist files were not updated since i couldn't make `npm run build-dist` run on Ubuntu ;)